### PR TITLE
feat: fallback to local domain (mdns) address

### DIFF
--- a/src/server/step-ca-admin.sh
+++ b/src/server/step-ca-admin.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+if [ "${DEBUG:-}" = 1 ]; then
+    set -x
+fi
+
 export STEPPATH="${STEPPATH:-/etc/step-ca}"
 PROVISION_PASSWORD_FILE="$STEPPATH/secrets/provisioner-password"
 


### PR DESCRIPTION
If the given PKI url fails, then fallback to the `.local` address (assuming that the device has a mdns resolver)