### PR TITLE
fix: remove conflicting files between server and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It is assumed that you have already installed thin-edge.io no the main device. I
     **Debian/Ubuntu**
 
     ```sh
-    apt-get install tedge-pki-smallstep-ca
+    apt-get install tedge-pki-smallstep-ca tedge-pki-smallstep-client
     ```
 
 2. Configure and start the step-ca server

--- a/images/main.dockerfile
+++ b/images/main.dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/thin-edge/tedge-demo-main-systemd
 
-COPY dist/tedge-pki-smallstep-ca*.deb /tmp/
+# Copy both ca and client
+COPY dist/tedge-pki-smallstep-*.deb /tmp/
 RUN apt-get update && apt-get install -y /tmp/*.deb

--- a/src/server/nfpm.yaml
+++ b/src/server/nfpm.yaml
@@ -28,52 +28,9 @@ contents:
       owner: tedge
       group: tedge
 
-  - src: ./src/server/step-ca-admin.sh
-    dst: /usr/bin/
-    file_info:
-      mode: 0755
-      owner: tedge
-      group: tedge
-
   - src: ./src/server/services/systemd/step-ca.service
     dst: /usr/lib/systemd/system/
     file_info:
       mode: 0755
       owner: tedge
       group: tedge
-
-  - src: ./src/client/services/systemd/cert-renewer@.service
-    dst: /usr/lib/systemd/system/
-    file_info:
-      mode: 0644
-      owner: tedge
-      group: tedge
-
-  - src: ./src/client/services/systemd/cert-renewer@.timer
-    dst: /usr/lib/systemd/system/
-    file_info:
-      mode: 0644
-      owner: tedge
-      group: tedge
-
-  - src: ./src/client/services/systemd/cert-renewer.target
-    dst: /usr/lib/systemd/system/
-    file_info:
-      mode: 0644
-      owner: tedge
-      group: tedge
-
-  # TODO: Add renewal service for the root and intermediate ca renewal
-  # - src: ./src/monitor/services/systemd/cert-renewer@.timer
-  #   dst: /usr/lib/systemd/system/
-  #   file_info:
-  #     mode: 0755
-  #     owner: tedge
-  #     group: tedge
-
-  # - src: ./src/monitor/services/systemd/cert-renewer.target
-  #   dst: /usr/lib/systemd/system/
-  #   file_info:
-  #     mode: 0755
-  #     owner: tedge
-  #     group: tedge


### PR DESCRIPTION
Fix the packaging between `tedge-pki-smallstep-ca` and `tedge-pki-smallstep-client` and instead make sure the files don't overlap.

On the main device (the PKI server), it requires both packages, where as on child devices, it only needs the client.