### PR TITLE
fix: improve .local domain fallback by also checking with curl

### DIFF
--- a/src/server/step-ca-admin.sh
+++ b/src/server/step-ca-admin.sh
@@ -250,7 +250,8 @@ EOT
 
         # Check if the url is resolvable, and if not, fallback to the .local address
         # Check with both step and curl as curl can have slightly different results
-        if ! step ca root --ca-url "$PKI_URL" --fingerprint "$FINGERPRINT" >/dev/null 2>&1 || ! curl -4 -s "$PKI_URL" >/dev/null 2>&1; then
+        # Note: curl insecure mode is only used to check if the address is reachable nothing more!
+        if ! step ca root --ca-url "$PKI_URL" --fingerprint "$FINGERPRINT" >/dev/null 2>&1 || ! curl -k -s "$PKI_URL" >/dev/null 2>&1; then
             case "$PKI_URL" in
                 http://*:*|https://*:*)
                     PKI_URL=$(echo "$PKI_URL" | sed 's/:\([0-9]*\)$/.local:\1/')

--- a/src/server/step-ca-admin.sh
+++ b/src/server/step-ca-admin.sh
@@ -249,7 +249,8 @@ EOT
         done
 
         # Check if the url is resolvable, and if not, fallback to the .local address
-        if ! step ca root --ca-url "$PKI_URL" --fingerprint "$FINGERPRINT" >/dev/null 2>&1; then
+        # Check with both step and curl as curl can have slightly different results
+        if ! step ca root --ca-url "$PKI_URL" --fingerprint "$FINGERPRINT" >/dev/null 2>&1 || ! curl -4 -s "$PKI_URL" >/dev/null 2>&1; then
             case "$PKI_URL" in
                 http://*:*|https://*:*)
                     PKI_URL=$(echo "$PKI_URL" | sed 's/:\([0-9]*\)$/.local:\1/')


### PR DESCRIPTION
Improve the .local domain fallback by also testing if curl can resolve the address as curl is used to verify the setup.

Sometimes the `step ca` test would work with the hostname, but using `curl` would not.