### PR TITLE
feat: add tedge as a valid dns/san name for the services

### DIFF
--- a/src/server/step-ca-init.sh
+++ b/src/server/step-ca-init.sh
@@ -60,6 +60,7 @@ step ca init \
     --name tedge-local \
     --dns=127.0.0.1 \
     --dns=localhost \
+    --dns=tedge \
     --dns="$(hostname)" \
     --dns="$(hostname).local" \
     --address=:8443
@@ -112,6 +113,7 @@ step certificate create \
     --force \
     --san=127.0.0.1 \
     --san=localhost \
+    --san=tedge \
     --san="$(hostname)" \
     --san="$(hostname).local" \
     "$@" \
@@ -147,6 +149,7 @@ step certificate create \
     --force \
     --san=127.0.0.1 \
     --san=localhost \
+    --san=tedge \
     --san="$(hostname)" \
     --san="$(hostname).local" \
     "$@" \


### PR DESCRIPTION
Add `tedge` to the list of valid names to reach the thin-edge.io services under.