### PR TITLE
fix(packaging): add missing dependency to client from the ca package

### DIFF
--- a/src/server/nfpm.yaml
+++ b/src/server/nfpm.yaml
@@ -20,6 +20,7 @@ apk:
 depends:
   - step-ca
   - step-cli
+  - tedge-pki-smallstep-client
 contents:
   - src: ./src/server/step-ca-init.sh
     dst: /usr/bin/


### PR DESCRIPTION
Since the tedge-pki-smallstep-ca package uses a script contained in the tedge-pki-smallstep-client, the package should have a dependency entry so that it is automatically installed.