### PR TITLE
fix: handle fingerprint and ca-url detection and allow users to be prompted for provisioner password

### DIFF
--- a/src/server/step-ca-admin.sh
+++ b/src/server/step-ca-admin.sh
@@ -1,22 +1,128 @@
 #!/bin/sh
 set -e
 
-if [ "${DEBUG:-}" = 1 ]; then
+command_usage() {
+    cat <<EOT
+thin-edge.io step-ca administration tasks to enroll and verify devices
+using certificates to enable secure communication using mtls
+
+USAGE
+
+    $0 <SUBCOMMANDS>
+
+Note: Use --help or -h to view the help for each subcommand, for example
+
+    $0 token --help
+
+    or
+
+    $0 enroll --help
+
+SUBCOMMANDS
+
+    token           Generate a one-time token to enroll a child device. This should be run on the main device
+    enroll          Enroll a child device using the one-time token generated via the 'token' command.
+                    This should be run on the child device
+    verify          Verify thin-edge.io services with mTLS
+
+EXAMPLES
+    $0 token child01        
+    # On main device, generate a token for 'child01', then copy/paste the command and execute on the child device
+EOT
+}
+
+ACTION=
+
+# Enable help and debugging early on without doing formal argument parsing
+for arg in "$@"; do
+    case "$arg" in
+        --debug)
+            DEBUG=1;
+            ;;
+        --help|-h)
+            command_usage
+            exit 0
+            ;;
+        --*|-*)
+            # ignore
+            ;;
+        *)
+            ACTION="$arg"
+            shift
+            # stop parsing as sub commands should handle their own help
+            break
+            ;;
+    esac
+done
+if [ "${DEBUG:-0}" = 1 ]; then
     set -x
 fi
 
 export STEPPATH="${STEPPATH:-/etc/step-ca}"
 PROVISION_PASSWORD_FILE=${PROVISION_PASSWORD_FILE:-"$STEPPATH/secrets/provisioner-password"}
 
+# Allow downloading the root ca from an untrusted root ca. Only turn on this if you are 100%
+# sure you can trust it (e.g. you are running in a controlled network)
+ALLOW_UNTRUSTED_ROOT_CA=${ALLOW_UNTRUSTED_ROOT_CA:-0}
+
 # Maximum time before giving up in the curl connection tests (in seconds)
 CONNECTION_TEST_TIMEOUT=${CONNECTION_TEST_TIMEOUT:-15}
 
-ACTION="$1"
-shift
+# ACTION="$1"
+# shift
+
+convert_to_local_domain() {
+    url="$1"
+    case "$url" in
+        http://*:*|https://*:*)
+            url=$(echo "$url" | sed 's/:\([0-9]*\)$/.local:\1/')
+            ;;
+        *)
+            url="${url}.local"
+            ;;
+    esac
+    echo "$url"
+}
+
+fetch_untrusted_root() {
+    output_file="$1"
+    shift
+
+    for url in "$@"; do
+        if curl -k -s "$url/roots.pem" > "$output_file"; then
+            return 0
+        fi
+    done
+
+    echo "Failed to download root ca from PKI server" >&2
+    return 1
+}
+
+verify_pki_url() {
+    fingerprint="$1"
+    shift
+
+    for url in "$@"; do
+        if ! step ca root --ca-url "$url" --fingerprint "$fingerprint" >/dev/null 2>&1; then
+            echo "Failed to reach PKI using 'step ca root'. url=$url" >&2
+            continue
+        fi
+        if ! curl -k -s "$url" >/dev/null 2>&1; then
+            echo "Failed to reach PKI using curl. url=$url" >&2
+            continue
+        fi
+        echo "Successfully reached PKI. url=$url" >&2
+        echo "$url"
+        return 0
+    done
+
+    echo "Failed resolve PKI url" >&2
+    return 1
+}
 
 check_services_using_tls() {
     echo
-    echo "Checking service status (with mTLS)"
+    echo "Checking service status (with mTLS)" >&2
     echo
 
     OK_COUNT=0
@@ -42,13 +148,13 @@ check_services_using_tls() {
         echo "    Cumulocity IoT Proxy: FAIL" >&2
     fi
 
-    printf "\nSummary\n\n"
+    printf "\nSummary\n\n" >&2
 
     if [ "$OK_COUNT" -ge 2 ]; then
-        printf '    OK - %s of 3 services are working\n\n' "$OK_COUNT"
+        printf '    OK - %s of 3 services are working\n\n' "$OK_COUNT" >&2
         return 0
     else
-        printf '    FAIL - Only %s of 3 services are working\n\n' "$OK_COUNT"
+        printf '    FAIL - Only %s of 3 services are working\n\n' "$OK_COUNT" >&2
         return 1
     fi
 }
@@ -58,7 +164,7 @@ case "$ACTION" in
         CN=${CN:-}
         HOST_NAME=${HOST_NAME:-}
 
-        usage() {
+        command_token_usage() {
             cat <<EOT
 Generate an enrollment command for a given child device name (which is used as the Common Name).
 A one-liner will be returned which can be used to enroll a child device which is running the
@@ -74,6 +180,7 @@ POSITIONAL ARGUMENTS
 FLAGS
     --host <STRING>          Explicit public name which the device is reachable for other devices.
                              For example, if you are using Azure then this might be the public IP address of the main device
+    --debug                  Enable debugging
     --help, -h               Show this help
 
 EXAMPLES
@@ -93,12 +200,15 @@ EOT
                     shift
                     ;;
                 --help|-h)
-                    usage
+                    command_token_usage
                     exit 0
                     ;;
+                --debug)
+                    # ignore as it is already handled at the top of the script
+                    ;;
                 --*|-*)
-                    echo "Unknown flag: $1"
-                    usage
+                    echo "Unknown flag: $1" >&2
+                    command_token_usage
                     exit 1
                     ;;
                 *)
@@ -172,13 +282,13 @@ EOT
     enrol|enroll)
         CN=${CN:-}
         PKI_URL=${PKI_URL:-"https://tedge:8443"}
-        CA_ROOT=${CA_ROOT:-}
+        CA_ROOT=${CA_ROOT:-"$STEPPATH/certs/root_ca.crt"}
         TOKEN=${TOKEN:-}
         FINGERPRINT=${FINGERPRINT:-}
         TARGET="${TARGET:-}"
         TOPIC_ID="${TOPIC_ID:-}"
 
-        usage() {
+        command_enroll_usage() {
             cat <<EOT
 Enroll a child device using the given PKI to generate the TLS certificates for secure communication.
 
@@ -199,10 +309,12 @@ FLAGS
                                           only valid for a given common name (set when creating the token)
     --root <path>                         Path to the root certificate
     --provisioner-password-file <path>    Provisioner password file to use for authentication instead of a token
+    --allow-insecure-root                Allow downloading from a potentially untrusted root ca. ENV ALLOW_UNTRUSTED_ROOT_CA=1
     --main-device <DNS|IP_ADDR>           DNS entry or IP address of the main device in case if it differs from
                                           the ca-url, otherwise the main-device value will be derived from the ca-url
     --topic-id <TOPIC_ID>                 4 part MQTT Topic ID used to address the default, e.g. device/child01//.
                                           Defaults to "device/<COMMON_NAME>//"
+    --debug                               Enable debugging
     --help, -h                            Show this help
 
 EXAMPLES
@@ -221,6 +333,9 @@ EXAMPLES
 
     $0 enroll mychild01 --ca-url https://tedge:8443 --root root_ca.pem --provisioner-password-file /run/password
     # Enrol a device using the provisioner password
+
+    $0 enroll mychild01 --ca-url https://tedge:8443 --allow-insecure-root
+    # Enrol a device and allow downloading the root certs from a potentiall untrusted root ca (not recommended in most scenarios)
 EOT
         }
 
@@ -250,17 +365,23 @@ EOT
                     FINGERPRINT="$2"
                     shift
                     ;;
+                --allow-insecure-root)
+                    ALLOW_UNTRUSTED_ROOT_CA=1
+                    ;;
                 --topic-id)
                     TOPIC_ID="$2"
                     shift
                     ;;
+                --debug)
+                    # ignore as it is already handled at the top of the script
+                    ;;
                 --help|-h)
-                    usage
+                    command_enroll_usage
                     exit 0
                     ;;
-                --*|*-)
-                    echo "Unknown flag: $1"
-                    usage
+                --*|-*)
+                    echo "Unknown flag: $1" >&2
+                    command_enroll_usage
                     exit 1
                     ;;
                 *)
@@ -275,22 +396,28 @@ EOT
         # Check with both step and curl as curl can have slightly different results
         # Note: curl insecure mode is only used to check if the address is reachable nothing more!
         if [ -z "$FINGERPRINT" ]; then
-            # Use a given CA root file to lookup the fingerprint, the presence of the root certificate establishes trust with the server
-            if [ -n "$CA_ROOT" ]; then
-                FINGERPRINT=$(step certificate fingerprint "$CA_ROOT")
+            if [ ! -f "$CA_ROOT" ]; then
+                if [ "$ALLOW_UNTRUSTED_ROOT_CA" = 1 ]; then
+                    echo "WARNING!!! Fetching root certificate from untrusted url" >&2
+                    CA_ROOT=root.pem
+                    fetch_untrusted_root "$CA_ROOT" "$PKI_URL" "$(convert_to_local_domain "$PKI_URL")"
+                fi
             fi
+            # Use a given CA root file to lookup the fingerprint, the presence of the root certificate establishes trust with the server
+            FINGERPRINT=$(step certificate fingerprint "$CA_ROOT")
         fi
 
-        if ! step ca root --ca-url "$PKI_URL" --fingerprint "$FINGERPRINT" >/dev/null 2>&1 || ! curl -k -s "$PKI_URL" >/dev/null 2>&1; then
-            case "$PKI_URL" in
-                http://*:*|https://*:*)
-                    PKI_URL=$(echo "$PKI_URL" | sed 's/:\([0-9]*\)$/.local:\1/')
-                    ;;
-                *)
-                    PKI_URL="${PKI_URL}.local"
-                    ;;
-            esac
-            echo "Resolving host failed, so trying local domain instead: $PKI_URL"
+        # Try multiple urls to find the one that is reachable from the client (e.g. given url then try the .local url)
+        RESOLVED_PKI_URL=$(verify_pki_url "$FINGERPRINT" "$PKI_URL" "$(convert_to_local_domain "$PKI_URL")" ||:)
+        if [ -z "$RESOLVED_PKI_URL" ]; then
+            echo "Resolving host failed. Could not resolve PKI server: $PKI_URL" >&2
+            exit 1
+        fi
+        PKI_URL="$RESOLVED_PKI_URL"
+
+        if [ -z "$FINGERPRINT" ]; then
+            echo "step-ca root certificate fingerprint was not provided or the was an error retrieving it from the step-ca server" >&2
+            exit 1
         fi
 
         step ca bootstrap --force --ca-url "$PKI_URL" --fingerprint "$FINGERPRINT" --install
@@ -299,23 +426,15 @@ EOT
         tedge config set device.key_path /etc/tedge/device-certs/tedge-agent.key
         tedge config set device.cert_path /etc/tedge/device-certs/tedge-agent.crt
 
-        echo "Creating child certificate"
+        echo "Requesting child certificate" >&2
+        # Note: requesting a certificate requires either --token or --root flags!
         if [ -n "$TOKEN" ]; then
             step ca certificate --force --kty=RSA --ca-url "$PKI_URL" --token "$TOKEN" "$CN" "$(tedge config get device.cert_path)" "$(tedge config get device.key_path)"
-        elif [ -n "$CA_ROOT" ]; then
-            if [ -n "$PROVISION_PASSWORD_FILE" ]; then
-                step ca certificate --force --kty=RSA --ca-url "$PKI_URL" --root "$CA_ROOT" --provisioner-password-file "$PROVISION_PASSWORD_FILE" "$CN" "$(tedge config get device.cert_path)" "$(tedge config get device.key_path)"
-            else
-                # This should let the user prompt
-                step ca certificate --force --kty=RSA --ca-url "$PKI_URL" --root "$CA_ROOT" "$CN" "$(tedge config get device.cert_path)" "$(tedge config get device.key_path)"
-            fi
+        elif [ -f "$PROVISION_PASSWORD_FILE" ]; then
+            step ca certificate --force --kty=RSA --ca-url "$PKI_URL" --root "$CA_ROOT" --provisioner-password-file "$PROVISION_PASSWORD_FILE" "$CN" "$(tedge config get device.cert_path)" "$(tedge config get device.key_path)"
         else
-            if [ -n "$PROVISION_PASSWORD_FILE" ]; then
-                step ca certificate --force --kty=RSA --ca-url "$PKI_URL" --provisioner-password-file "$PROVISION_PASSWORD_FILE" "$CN" "$(tedge config get device.cert_path)" "$(tedge config get device.key_path)"
-            else
-                # This should let the user prompt
-                step ca certificate --force --kty=RSA --ca-url "$PKI_URL" "$CN" "$(tedge config get device.cert_path)" "$(tedge config get device.key_path)"
-            fi
+            # User will be prompted for the provisioner password
+            step ca certificate --force --kty=RSA --ca-url "$PKI_URL" --root "$CA_ROOT" "$CN" "$(tedge config get device.cert_path)" "$(tedge config get device.key_path)"
         fi
 
         # Set permissions (before moving them)
@@ -332,7 +451,7 @@ EOT
             TOPIC_ID="device/$CN//"
         fi
 
-        echo "Configuring tedge-agent as a child device connecting to $TOPIC_ID"
+        echo "Configuring tedge-agent as a child device connecting to $TOPIC_ID" >&2
         tedge config set mqtt.device_topic_id "$TOPIC_ID"
 
         # thin-edge.io File Transfer Service
@@ -360,7 +479,7 @@ EOT
 
         # Enable services
         if command -V systemctl >/dev/null 2>&1; then
-            echo "Starting/enabling tedge-agent"
+            echo "Starting/enabling tedge-agent" >&2
             systemctl enable tedge-agent
 
             # Disable services that don't work on child devices
@@ -382,13 +501,13 @@ EOT
             systemctl mask collectd >/dev/null 2>&1 ||:
         fi
 
-        echo "The child device has been successfully enrolled"
+        echo "The child device has been successfully enrolled" >&2
         ;;
     delete-ca)
         #
         # Delete all of the existing step-ca configuration and root certificate
         #
-        echo "Deleting the existing step-ca configuration (this will invalidate all existing certificates!)"
+        echo "Deleting the existing step-ca configuration (this will invalidate all existing certificates!)" >&2
         rm -rf "$STEPPATH"
         rm -f \
             /usr/local/share/ca-certificates/root_ca.crt \


### PR DESCRIPTION
Fix enrollment command whilst improving the debuggability/flow.

Changes include:

* Allow users to be prompted for the provioner password when a token is not provided
* Add support for `--debug` flag to avoid problems with passing variables to sudo
* Add option to download the root ca from an untrusted source (though only if opted into for controlled networks like containers)
* Show command usage on root command