### PR TITLE
feat: store mosquitto config under /etc/tedge/mosquitto-conf folder

### DIFF
--- a/images/child.dockerfile
+++ b/images/child.dockerfile
@@ -1,4 +1,4 @@
 FROM ghcr.io/thin-edge/tedge-demo-main-systemd
 
 COPY dist/tedge-pki-smallstep-client*.deb /tmp/
-RUN apt-get update && apt-get install -y /tmp/*.deb
+RUN apt-get update && apt-get install -y --allow-downgrades /tmp/*.deb

--- a/images/main.dockerfile
+++ b/images/main.dockerfile
@@ -2,4 +2,4 @@ FROM ghcr.io/thin-edge/tedge-demo-main-systemd
 
 # Copy both ca and client
 COPY dist/tedge-pki-smallstep-*.deb /tmp/
-RUN apt-get update && apt-get install -y /tmp/*.deb
+RUN apt-get update && apt-get install -y --allow-downgrades /tmp/*.deb

--- a/src/server/scripts/post-install
+++ b/src/server/scripts/post-install
@@ -45,6 +45,15 @@ cleanInstall() {
 
 upgrade() {
     printf "\033[32m Post Install of an upgrade\033[0m\n"
+    if [ -f /etc/mosquitto/conf.d/tls-listener.conf ]; then
+      echo "Moving /etc/mosquitto/conf.d/tls-listener.conf to /etc/tedge/mosquitto-conf/"
+      if mv /etc/mosquitto/conf.d/tls-listener.conf /etc/tedge/mosquitto-conf/; then
+        if [ "${use_systemctl}" = "True" ]; then
+          systemctl restart mosquitto ||:
+        fi
+      fi
+    fi
+
     cleanInstall
 }
 

--- a/src/server/step-ca-init.sh
+++ b/src/server/step-ca-init.sh
@@ -249,9 +249,14 @@ fi
 # tedge config set mqtt.external.cert_file "$(step path)/certs/intermediate_ca.crt"
 # tedge config set mqtt.external.key_file "$(step path)/secrets/intermediate_ca_key"
 
-# FIXME: should thin-edge.io support the external listener insteaf of having to edit the mosquitto configure directly
-# TODO: Where can the tls listener be added to, conf.d, or /etc/tedge/mosquitto-conf/?
-cat << EOF > "/etc/mosquitto/conf.d/tls-listener.conf"
+# Store external listener under /etc/tedge/mosquitto-conf so it can be more easily backed up
+# during A/B updates as the /etc/tedge folder is generally already handled by firmware
+# update logic
+# In previous releases of tedge-pki-smallstep, it stored the location under /etc/mosquitto/conf.d/tls-listener.conf
+# so remove it and replace it with the updated path.
+# Remove previous location of file
+rm -f /etc/mosquitto/conf.d/tls-listener.conf
+cat << EOF > "/etc/tedge/mosquitto-conf/tls-listener.conf"
 listener 8883 0.0.0.0
 allow_anonymous false
 require_certificate true


### PR DESCRIPTION
Store the tls listener configuration under `/etc/tedge/mosquitto-conf` instead of `/etc/mosquitto/conf.d` as the former location is usually backed up along with other tedge configuration when doing OS A/B updates (e.g. firmware updates), otherwise if the user does copy the tls listener it can result in all components not being able to communicate to the local MQTT broker